### PR TITLE
Configure setuptools package dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [build-system]
 requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
@@ -25,6 +24,9 @@ torch = ["torch", "torchvision"]
 tf = ["tensorflow>=2.12"]
 tflite = ["tensorflow"]
 dev = ["ruff", "pytest"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary
- add setuptools package directory mapping for the src layout

## Testing
- pip install -e .
- python -c "from mobile_gradio_classifier import MobileClassifierApp"

------
https://chatgpt.com/codex/tasks/task_e_68d58af0bbfc8322b1dd4da4924d3f30