### PR TITLE
Add fallback demo model for TensorFlow Keras example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ app.launch(share=True)
 All three scripts look for a `classes.txt` file that lives right next to them in `examples/` (a starter copy with two placeholder labels ships with the repo).
 Edit that file with one label per line to match your model's outputs. If you delete it or leave it empty, the scripts will fall back to a pair of dummy labels so you can still launch the UI for smoke testing.
 
+To plug in a real TensorFlow/Keras model for the `tf_keras_example.py` demo, export it as a `.keras` file and point the script to it with the `MODEL_PATH` environment variable:
+
+```bash
+MODEL_PATH=/path/to/your/model.keras python examples/tf_keras_example.py
+```
+If that variable is unset or the file cannot be found, the example will build a lightweight in-memory demo network so you can still try the app flow without a trained model.
+
 ## Module API
 
 ### `MobileClassifierApp`

--- a/examples/tf_keras_example.py
+++ b/examples/tf_keras_example.py
@@ -1,8 +1,13 @@
 
 # examples/tf_keras_example.py
-import os, numpy as np, tensorflow as tf
+import logging
+import os
 from pathlib import Path
+
+import numpy as np
+import tensorflow as tf
 from PIL import Image
+
 from mobile_gradio_classifier import MobileClassifierApp
 
 MODEL_PATH = os.environ.get("MODEL_PATH", "model.keras")
@@ -13,18 +18,39 @@ if classes_path.exists():
     classes = [line.strip() for line in classes_path.read_text().splitlines() if line.strip()] or DEFAULT_CLASSES
 else:
     classes = DEFAULT_CLASSES
-model = tf.keras.models.load_model(MODEL_PATH)
+
+def build_demo_model(img_size: int, num_classes: int) -> tf.keras.Model:
+    """Create a lightweight classifier for demo purposes."""
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.InputLayer(input_shape=(img_size, img_size, 3)),
+            tf.keras.layers.Flatten(),
+            tf.keras.layers.Dense(64, activation="relu"),
+            tf.keras.layers.Dense(num_classes, activation="softmax"),
+        ]
+    )
+    return model
+
+
+model_path = Path(MODEL_PATH)
+if model_path.is_file():
+    model = tf.keras.models.load_model(model_path)
+else:
+    logging.getLogger(__name__).warning(
+        "MODEL_PATH '%s' not found. Using in-memory demo model instead.", model_path
+    )
+    model = build_demo_model(IMG_SIZE, len(classes))
 
 def _preprocess_rgb(pil: Image.Image):
     arr = tf.image.resize(np.array(pil.convert("RGB")), (IMG_SIZE, IMG_SIZE)).numpy()
-    arr = arr.astype("float32")/255.0
+    arr = arr.astype("float32") / 255.0
     return arr[None, ...]
 
 def predict_fn(pil: Image.Image):
     y = model.predict(_preprocess_rgb(pil), verbose=0)[0]
     if (y < 0).any() or not np.allclose(y.sum(), 1.0, atol=1e-3):
         y = tf.nn.softmax(y).numpy()
-    return {c: float(p) for c,p in zip(classes, y)}
+    return {c: float(p) for c, p in zip(classes, y)}
 
 app = MobileClassifierApp(classes, predict_fn=predict_fn)
 app.launch(share=True)


### PR DESCRIPTION
## Summary
- add a helper to build an in-memory demo model when the configured Keras model file is absent
- ensure the TensorFlow example logs a warning about the fallback and uses existing preprocessing
- document how to point the example to a real `.keras` model via the `MODEL_PATH` environment variable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d88af6fb348322b256a5e49bca84e8