### PR TITLE
Add PyYAML dependency and CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,13 @@ dependencies = [
     "gradio>=4.0.0",
     "pillow>=9.5.0",
     "numpy>=1.24.0",
+    "PyYAML>=6.0",
     # optional video backends (recommended):
     "imageio>=2.31.0",
 ]
+
+[project.scripts]
+mobile-export-frames = "mobile_gradio_classifier.export_frames:cli"
 
 [project.optional-dependencies]
 video = ["opencv-python>=4.5.0"]


### PR DESCRIPTION
## Summary
- add PyYAML to the core dependencies so YAML configs load without extra installs
- register the export-frames CLI entry point for the console script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd8a2dfd5c83229693344cdc0e12ff