### PR TITLE
Add frame export configuration example and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,31 @@ MODEL_PATH=/path/to/your/model.keras python examples/tf_keras_example.py
 ```
 If that variable is unset or the file cannot be found, the example will build a lightweight in-memory demo network so you can still try the app flow without a trained model.
 
+## Exporting frames from videos
+
+Use the `mobile_gradio_classifier.export_frames` module (or the `mobile-export-frames` console entry point) to turn a batch of videos into resized image sequences that mirror the structure expected by `MobileClassifierApp`. A sample configuration lives at [`examples/frame_export.yaml`](examples/frame_export.yaml).
+
+```bash
+python -m mobile_gradio_classifier.export_frames --config examples/frame_export.yaml
+# or
+mobile-export-frames --config examples/frame_export.yaml
+```
+
+The tool accepts one or more `input_glob` patterns and writes every matched video to its own subdirectory inside `output_dir`. For example, when `output_dir` is `exports/frames` and a source file named `clip.mp4` is processed, frames are saved under `exports/frames/clip/clip_000000.png`, `clip_000001.png`, and so on. File names include a zero-padded index that reflects the sampling order at the requested `fps`, and the image format is derived from the `format` value in the config (`png`, `jpeg`, etc.). Frames are resized to `size` using Pillow's high-quality `LANCZOS` filter.
+
+### Optional dependencies
+
+Reading videos requires either `opencv-python` or `imageio`; the exporter will automatically prefer OpenCV and fall back to ImageIO if only that package is available. Install whichever backend fits your environment:
+
+```bash
+pip install mobile-gradio-classifier[video]
+# or explicitly
+pip install opencv-python  # OpenCV backend
+pip install imageio        # ImageIO fallback backend
+```
+
+Resizing is handled by Pillow (installed with the base package). Its `LANCZOS` filter ensures high-quality downsampling, which is particularly helpful when generating datasets for model training or validation.
+
 ## Module API
 
 ### `MobileClassifierApp`

--- a/examples/frame_export.yaml
+++ b/examples/frame_export.yaml
@@ -1,0 +1,14 @@
+# Example configuration for the frame export utility.
+# You can list one or more glob patterns; each matching video will be processed.
+input_glob:
+  - "data/videos/*.mp4"
+  - "data/videos/*.mov"
+# Frames from each input video will be written to its own subfolder in this directory.
+output_dir: "exports/frames"
+# Target sampling rate (frames per second) when reading the source video.
+fps: 2.0
+# Output frame size as [width, height] in pixels. Frames are resized with Pillow's LANCZOS filter.
+size: [224, 224]
+# Image format/extension for the exported frames (e.g. "png", "jpeg").
+format: "png"
+# overwrite: true  # Uncomment to replace frames if they already exist.


### PR DESCRIPTION
## Summary
- add a sample YAML config that documents the frame exporter's required keys
- document how to run the frame export CLI/module and describe the output layout
- call out optional OpenCV/ImageIO dependencies and Pillow resizing behavior

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dd8a8adbc88322b94ad4da38a54738