### PR TITLE
Enable webcam input for video capture

### DIFF
--- a/src/mobile_gradio_classifier/core.py
+++ b/src/mobile_gradio_classifier/core.py
@@ -254,7 +254,11 @@ class MobileClassifierApp:
 
             with gr.Tab("Video"):
                 with gr.Row():
-                    vid_in = gr.Video(label="Upload or record a short video")
+                    vid_in = gr.Video(
+                        label="Upload or record a short video",
+                        sources=["upload", "webcam"],
+                        format="mp4",
+                    )
                 with gr.Row():
                     fps_in = gr.Slider(0.5, 10.0, value=self.default_video_fps, step=0.5, label="Target FPS for sampling")
                     agg_in = gr.Dropdown(choices=["majority", "avg"], value="majority", label="Aggregation")


### PR DESCRIPTION
## Summary
- allow the video input component to accept both uploads and webcam recordings by setting sources
- specify MP4 as the expected format for the video input so Gradio exposes the webcam recorder

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68de921858cc83228054fff0b759a271