### PR TITLE
Remove hard-coded MP4 format from Gradio video input

### DIFF
--- a/src/mobile_gradio_classifier/core.py
+++ b/src/mobile_gradio_classifier/core.py
@@ -257,7 +257,6 @@ class MobileClassifierApp:
                     vid_in = gr.Video(
                         label="Upload or record a short video",
                         sources=["upload", "webcam"],
-                        format="mp4",
                     )
                 with gr.Row():
                     fps_in = gr.Slider(0.5, 10.0, value=self.default_video_fps, step=0.5, label="Target FPS for sampling")


### PR DESCRIPTION
## Summary
- allow Gradio to select its default encoding for the video input by removing the forced MP4 format

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de9686f4f0832282a89e03c396d607