### PR TITLE
Pin Gradio 3.50.2 and update demo for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **model-agnostic, resolution-agnostic** Gradio wrapper for **image and video classification**, built to be **pippable** and easy to run on phones via `share=True` in Colab.
 
 ## Features
-- 📷 Image input (upload / webcam) & 🎥 Video input (upload / camera)
+- 📷 Image input (upload by default; set `source="webcam"` in `core.py` to capture directly) & 🎥 Video input (upload by default; set `source="webcam"` to record)
 - ⏱ Sample video at target FPS; aggregate by **majority** or **average prob**
 - 🔁 Optional continuous webcam mode with adjustable classification frequency
 - 🔌 Works with **any classifier**:
@@ -13,6 +13,8 @@ A **model-agnostic, resolution-agnostic** Gradio wrapper for **image and video c
   - Plug a **PyTorch** model + `preprocess_fn`, or use **TensorFlow/TFLite** with a `predict_fn`
 - ✉️ Optional email alerts when a label is detected above threshold
 - 📱 One line to launch a public link for mobile testing
+
+> **Gradio compatibility:** The project now pins **Gradio 3.50.2** for long-term stability. This release expects a single `source` string per media component (e.g., `"upload"` or `"webcam"`). The defaults favor uploads, but you can switch sources in `MobileClassifierApp.build_demo()` if you want webcam-first behavior.
 
 ## Install (editable dev mode)
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9"
 license = {text = "MIT"}
 authors = [{name = "Course Staff", email = "noreply@example.edu"}]
 dependencies = [
-    "gradio>=4.0.0",
+    "gradio==3.50.2",
     "pillow>=9.5.0",
     "numpy>=1.24.0",
     "PyYAML>=6.0",

--- a/src/mobile_gradio_classifier/core.py
+++ b/src/mobile_gradio_classifier/core.py
@@ -242,7 +242,7 @@ class MobileClassifierApp:
 
             with gr.Tab("Image"):
                 with gr.Row():
-                    img_in = gr.Image(sources=["upload", "webcam"], label="Upload or take a photo", streaming=False)
+                    img_in = gr.Image(source="upload", label="Upload or take a photo", streaming=False)
                     with gr.Column():
                         send_email_chk = gr.Checkbox(label="Send email on detection", value=False)
                         out_label = gr.Label(label="Top Prediction")
@@ -256,7 +256,7 @@ class MobileClassifierApp:
                 with gr.Row():
                     vid_in = gr.Video(
                         label="Upload or record a short video",
-                        sources=["upload", "webcam"],
+                        source="upload",
                     )
                 with gr.Row():
                     fps_in = gr.Slider(0.5, 10.0, value=self.default_video_fps, step=0.5, label="Target FPS for sampling")
@@ -275,7 +275,7 @@ class MobileClassifierApp:
                     live_toggle = gr.Checkbox(label="Enable live classification", value=False)
                     live_freq = gr.Slider(0.5, 5.0, value=1.0, step=0.5, label="Classification frequency (Hz)")
                 with gr.Row():
-                    live_feed = gr.Image(label="Webcam stream", sources=["webcam"], streaming=True)
+                    live_feed = gr.Image(label="Webcam stream", source="webcam", streaming=True)
                     with gr.Column():
                         live_label = gr.Label(label="Live Top Prediction")
                         live_probs = gr.Label(label="Live Class Probabilities")


### PR DESCRIPTION
## Summary
- pin the project dependency to Gradio 3.50.2 for consistent behavior
- update the Blocks layout to use media component arguments that exist in 3.50.2
- document the Gradio pin and how to switch media sources when using the packaged demo

## Testing
- `pip install -e .[video]`
- `python - <<'PY'
from mobile_gradio_classifier import MobileClassifierApp
from PIL import Image

def predict_fn(pil: Image.Image):
    return {"class_a": 0.6, "class_b": 0.4}

app = MobileClassifierApp(["class_a", "class_b"], predict_fn=predict_fn)
demo = app.build_demo()
demo.launch(prevent_thread_lock=True)
demo.close()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68deb21f9d708322b646f43ac34b084c